### PR TITLE
Common test runner code.

### DIFF
--- a/bitcoin_cash_test.go
+++ b/bitcoin_cash_test.go
@@ -1,20 +1,14 @@
 package coincodec
 
 import (
-	"encoding/hex"
-	"reflect"
 	"testing"
 
 	"github.com/pkg/errors"
+	"github.com/wealdtech/go-slip44"
 )
 
-func TestBitcoinCashDecodeToBytes(t *testing.T) {
-	tests := []struct {
-		name   string
-		input  string
-		output string
-		err    error
-	}{
+func TestBitcoinCashEncodeToBytes(t *testing.T) {
+	tests := []TestcaseEncode {
 		{
 			name:   "P2PKH",
 			input:  "1BpEi6DfDAUFd7GtittLSdBeYJvcoaVggu",
@@ -38,7 +32,7 @@ func TestBitcoinCashDecodeToBytes(t *testing.T) {
 		{
 			name:  "Empty",
 			input: "",
-			err:   errors.New("invalid address"),
+			err:   errors.New("empty input"),
 		},
 		{
 			name:  "Testnet",
@@ -46,46 +40,23 @@ func TestBitcoinCashDecodeToBytes(t *testing.T) {
 			err:   errors.New("invalid hrp"),
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := BitcoinCashDecodeToBytes(tt.input)
-			if tt.err != nil {
-				if err.Error() != tt.err.Error() {
-					t.Errorf("BitcoinDecodeToBytes() error = %v, wantErr %v", err, tt.err)
-					return
-				}
-			} else {
-				if !reflect.DeepEqual(hex.EncodeToString(got), tt.output) {
-					t.Errorf("BitcoinDecodeToBytes() = %v, want %v, err: %v", hex.EncodeToString(got), tt.output, tt.err)
-				}
-			}
-		})
-	}
+
+	RunTestsEncode(t, slip44.BITCOIN_CASH, tests)
 }
 
-func TestBitcoinCashEncodeToString(t *testing.T) {
-	script1, _ := hex.DecodeString("76a914cb481232299cd5743151ac4b2d63ae198e7bb0a988ac")
-	script2, _ := hex.DecodeString("a914cb481232299cd5743151ac4b2d63ae198e7bb0a987")
+func TestBitcoinCashDecodeToString(t *testing.T) {
+	script1 := "76a914cb481232299cd5743151ac4b2d63ae198e7bb0a988ac"
+	script2 := "a914cb481232299cd5743151ac4b2d63ae198e7bb0a987"
 
-	tests := []struct {
-		name   string
-		input  []byte
-		output string
-		err    error
-	}{
-		{
-			name:  "Nil",
-			input: nil,
-			err:   errors.New("invalid data length"),
-		},
+	tests := []TestcaseDecode {
 		{
 			name:  "Empty",
-			input: []byte{},
-			err:   errors.New("invalid data length"),
+			input: "",
+			err:   errors.New("empty input"),
 		},
 		{
 			name:  "Wrong script",
-			input: []byte{0x00, 0x14, 0x01, 0x2},
+			input: "00140102",
 			err:   errors.New("wrong script data"),
 		},
 		{
@@ -99,19 +70,6 @@ func TestBitcoinCashEncodeToString(t *testing.T) {
 			output: "bitcoincash:pr95sy3j9xwd2ap32xkykttr4cvcu7as4yc93ky28e",
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := BitcoinCashEncodeToString(tt.input)
-			if tt.err != nil {
-				if err.Error() != tt.err.Error() {
-					t.Errorf("BitcoinEncodeToString() error = %v, wantErr %v", err, tt.err)
-					return
-				}
-			} else {
-				if got != tt.output {
-					t.Errorf("BitcoinEncodeToString() = %v, want %v", got, tt.output)
-				}
-			}
-		})
-	}
+
+	RunTestsDecode(t, slip44.BITCOIN_CASH, tests)
 }

--- a/bitcoin_cash_test.go
+++ b/bitcoin_cash_test.go
@@ -52,7 +52,7 @@ func TestBitcoinCashDecodeToString(t *testing.T) {
 		{
 			name:  "Empty",
 			input: "",
-			err:   errors.New("empty input"),
+			err:   errors.New("invalid data length"),
 		},
 		{
 			name:  "Wrong script",

--- a/bitcoin_cash_test.go
+++ b/bitcoin_cash_test.go
@@ -32,7 +32,7 @@ func TestBitcoinCashEncodeToBytes(t *testing.T) {
 		{
 			name:  "Empty",
 			input: "",
-			err:   errors.New("empty input"),
+			err:   errors.New("invalid address"),
 		},
 		{
 			name:  "Testnet",

--- a/bitcoin_forks_test.go
+++ b/bitcoin_forks_test.go
@@ -1,21 +1,14 @@
 package coincodec
 
 import (
-	"encoding/hex"
-	"reflect"
 	"testing"
 
 	"github.com/pkg/errors"
 	"github.com/wealdtech/go-slip44"
 )
 
-func TestLitecoinDecodeToBytes(t *testing.T) {
-	tests := []struct {
-		name   string
-		input  string
-		output string
-		err    error
-	}{
+func TestLitecoinEncodeToBytes(t *testing.T) {
+	tests := []TestcaseEncode {
 		{
 			name:   "P2PKH",
 			input:  "LaMT348PWRnrqeeWArpwQPbuanpXDZGEUz",
@@ -32,34 +25,16 @@ func TestLitecoinDecodeToBytes(t *testing.T) {
 			output: "0014687c150c26af5493befeed7036043812115ca36c",
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := toBytesMap[slip44.LITECOIN](tt.input)
-			if tt.err != nil {
-				if err.Error() != tt.err.Error() {
-					t.Errorf("BitcoinDecodeToBytes() error = %v, wantErr %v", err, tt.err)
-					return
-				}
-			} else {
-				if !reflect.DeepEqual(hex.EncodeToString(got), tt.output) {
-					t.Errorf("BitcoinDecodeToBytes() = %v, want %v, err: %v", hex.EncodeToString(got), tt.output, tt.err)
-				}
-			}
-		})
-	}
+
+	RunTestsEncode(t, slip44.LITECOIN, tests)
 }
 
-func TestLitecoinEncodeToString(t *testing.T) {
-	script1, _ := hex.DecodeString("76a914a5f4d12ce3685781b227c1f39548ddef429e978388ac")
-	script2, _ := hex.DecodeString("a914b48297bff5dadecc5f36145cec6a5f20d57c8f9b87")
-	script3, _ := hex.DecodeString("0014687c150c26af5493befeed7036043812115ca36c")
+func TestLitecoinDecodeToString(t *testing.T) {
+	script1 := "76a914a5f4d12ce3685781b227c1f39548ddef429e978388ac"
+	script2 := "a914b48297bff5dadecc5f36145cec6a5f20d57c8f9b87"
+	script3 := "0014687c150c26af5493befeed7036043812115ca36c"
 
-	tests := []struct {
-		name   string
-		input  []byte
-		output string
-		err    error
-	}{
+	tests := []TestcaseDecode {
 		{
 			name:   "P2PKH",
 			input:  script1,
@@ -76,30 +51,12 @@ func TestLitecoinEncodeToString(t *testing.T) {
 			output: "ltc1qdp7p2rpx4a2f80h7a4crvppczgg4egmv5c78w8",
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := toStringMap[slip44.LITECOIN](tt.input)
-			if tt.err != nil {
-				if err.Error() != tt.err.Error() {
-					t.Errorf("BitcoinEncodeToString() error = %v, wantErr %v", err, tt.err)
-					return
-				}
-			} else {
-				if got != tt.output {
-					t.Errorf("BitcoinEncodeToString() = %v, want %v", got, tt.output)
-				}
-			}
-		})
-	}
+
+	RunTestsDecode(t, slip44.LITECOIN, tests)
 }
 
-func TestDogeDecodeToBytes(t *testing.T) {
-	tests := []struct {
-		name   string
-		input  string
-		output string
-		err    error
-	}{
+func TestDogeEncodeToBytes(t *testing.T) {
+	tests := []TestcaseEncode {
 		{
 			name:   "P2PKH",
 			input:  "DBXu2kgc3xtvCUWFcxFE3r9hEYgmuaaCyD",
@@ -111,33 +68,15 @@ func TestDogeDecodeToBytes(t *testing.T) {
 			output: "a914f8f5d99a9fc21aa676e74d15e7b8134557615bda87",
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := toBytesMap[slip44.DOGECOIN](tt.input)
-			if tt.err != nil {
-				if err.Error() != tt.err.Error() {
-					t.Errorf("BitcoinDecodeToBytes() error = %v, wantErr %v", err, tt.err)
-					return
-				}
-			} else {
-				if !reflect.DeepEqual(hex.EncodeToString(got), tt.output) {
-					t.Errorf("BitcoinDecodeToBytes() = %v, want %v, err: %v", hex.EncodeToString(got), tt.output, tt.err)
-				}
-			}
-		})
-	}
+
+	RunTestsEncode(t, slip44.DOGECOIN, tests)
 }
 
-func TestDogeEncodeToString(t *testing.T) {
-	script1, _ := hex.DecodeString("76a9144620b70031f0e9437e374a2100934fba4911046088ac")
-	script2, _ := hex.DecodeString("a914f8f5d99a9fc21aa676e74d15e7b8134557615bda87")
+func TestDogeDecodeToString(t *testing.T) {
+	script1 := "76a9144620b70031f0e9437e374a2100934fba4911046088ac"
+	script2 := "a914f8f5d99a9fc21aa676e74d15e7b8134557615bda87"
 
-	tests := []struct {
-		name   string
-		input  []byte
-		output string
-		err    error
-	}{
+	tests := []TestcaseDecode {
 		{
 			name:   "P2PKH",
 			input:  script1,
@@ -149,30 +88,12 @@ func TestDogeEncodeToString(t *testing.T) {
 			output: "AF8ekvSf6eiSBRspJjnfzK6d1EM6pnPq3G",
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := toStringMap[slip44.DOGECOIN](tt.input)
-			if tt.err != nil {
-				if err.Error() != tt.err.Error() {
-					t.Errorf("BitcoinEncodeToString() error = %v, wantErr %v", err, tt.err)
-					return
-				}
-			} else {
-				if got != tt.output {
-					t.Errorf("BitcoinEncodeToString() = %v, want %v", got, tt.output)
-				}
-			}
-		})
-	}
+
+	RunTestsDecode(t, slip44.DOGECOIN, tests)
 }
 
-func TestDashDecodeToBytes(t *testing.T) {
-	tests := []struct {
-		name   string
-		input  string
-		output string
-		err    error
-	}{
+func TestDashEncodeToBytes(t *testing.T) {
+	tests := []TestcaseEncode {
 		{
 			name:   "P2PKH",
 			input:  "XtAG1982HcYJVibHxRZrBmdzL5YTzj4cA1",
@@ -189,33 +110,15 @@ func TestDashDecodeToBytes(t *testing.T) {
 			err:   errors.New("invalid format: version and/or checksum bytes missing"),
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := toBytesMap[slip44.DASH](tt.input)
-			if tt.err != nil {
-				if err.Error() != tt.err.Error() {
-					t.Errorf("BitcoinDecodeToBytes() error = %v, wantErr %v", err, tt.err)
-					return
-				}
-			} else {
-				if !reflect.DeepEqual(hex.EncodeToString(got), tt.output) {
-					t.Errorf("BitcoinDecodeToBytes() = %v, want %v, err: %v", hex.EncodeToString(got), tt.output, tt.err)
-				}
-			}
-		})
-	}
+
+	RunTestsEncode(t, slip44.DASH, tests)
 }
 
-func TestDashEncodeToString(t *testing.T) {
-	script1, _ := hex.DecodeString("76a914bfa98bb8a919330c432e4ff16563c5ab449604ad88ac")
-	script2, _ := hex.DecodeString("a9149d646d71f0815c0cfd8cd08aa9d391cd127f378687")
+func TestDashDecodeToString(t *testing.T) {
+	script1 := "76a914bfa98bb8a919330c432e4ff16563c5ab449604ad88ac"
+	script2 := "a9149d646d71f0815c0cfd8cd08aa9d391cd127f378687"
 
-	tests := []struct {
-		name   string
-		input  []byte
-		output string
-		err    error
-	}{
+	tests := []TestcaseDecode {
 		{
 			name:   "P2PKH",
 			input:  script1,
@@ -227,30 +130,12 @@ func TestDashEncodeToString(t *testing.T) {
 			output: "7gks9gWVmGeir7m4MhsSxMzXC2eXXAuuRD",
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := toStringMap[slip44.DASH](tt.input)
-			if tt.err != nil {
-				if err.Error() != tt.err.Error() {
-					t.Errorf("BitcoinEncodeToString() error = %v, wantErr %v", err, tt.err)
-					return
-				}
-			} else {
-				if got != tt.output {
-					t.Errorf("BitcoinEncodeToString() = %v, want %v", got, tt.output)
-				}
-			}
-		})
-	}
+
+	RunTestsDecode(t, slip44.DASH, tests)
 }
 
-func TestMonaDecodeToBytes(t *testing.T) {
-	tests := []struct {
-		name   string
-		input  string
-		output string
-		err    error
-	}{
+func TestMonaEncodeToBytes(t *testing.T) {
+	tests := []TestcaseEncode {
 		{
 			name:   "P2PKH",
 			input:  "MHxgS2XMXjeJ4if2PRRbWYcdwZPWfdwaDT",
@@ -267,34 +152,16 @@ func TestMonaDecodeToBytes(t *testing.T) {
 			output: "0014751e76e8199196d454941c45d1b3a323f1433bd6",
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := toBytesMap[slip44.MONACOIN](tt.input)
-			if tt.err != nil {
-				if err.Error() != tt.err.Error() {
-					t.Errorf("BitcoinDecodeToBytes() error = %v, wantErr %v", err, tt.err)
-					return
-				}
-			} else {
-				if !reflect.DeepEqual(hex.EncodeToString(got), tt.output) {
-					t.Errorf("BitcoinDecodeToBytes() = %v, want %v, err: %v", hex.EncodeToString(got), tt.output, tt.err)
-				}
-			}
-		})
-	}
+
+	RunTestsEncode(t, slip44.MONACOIN, tests)
 }
 
-func TestMonaEncodeToString(t *testing.T) {
-	script1, _ := hex.DecodeString("76a9146e5bb7226a337fe8307b4192ae5c3fab9fa9edf588ac")
-	script2, _ := hex.DecodeString("a9146449f568c9cd2378138f2636e1567112a184a9e887")
-	script3, _ := hex.DecodeString("0014751e76e8199196d454941c45d1b3a323f1433bd6")
+func TestMonaDecodeToString(t *testing.T) {
+	script1 := "76a9146e5bb7226a337fe8307b4192ae5c3fab9fa9edf588ac"
+	script2 := "a9146449f568c9cd2378138f2636e1567112a184a9e887"
+	script3 := "0014751e76e8199196d454941c45d1b3a323f1433bd6"
 
-	tests := []struct {
-		name   string
-		input  []byte
-		output string
-		err    error
-	}{
+	tests := []TestcaseDecode {
 		{
 			name:   "P2PKH",
 			input:  script1,
@@ -311,30 +178,12 @@ func TestMonaEncodeToString(t *testing.T) {
 			output: "mona1qw508d6qejxtdg4y5r3zarvary0c5xw7kg5lnx5",
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := toStringMap[slip44.MONACOIN](tt.input)
-			if tt.err != nil {
-				if err.Error() != tt.err.Error() {
-					t.Errorf("BitcoinEncodeToString() error = %v, wantErr %v", err, tt.err)
-					return
-				}
-			} else {
-				if got != tt.output {
-					t.Errorf("BitcoinEncodeToString() = %v, want %v", got, tt.output)
-				}
-			}
-		})
-	}
+
+	RunTestsDecode(t, slip44.MONACOIN, tests)
 }
 
-func TestQtumDecodeToBytes(t *testing.T) {
-	tests := []struct {
-		name   string
-		input  string
-		output string
-		err    error
-	}{
+func TestQtumEncodeToBytes(t *testing.T) {
+	tests := []TestcaseEncode {
 		{
 			name:   "P2PKH",
 			input:  "QYJHEEt8kS8TzUuCy1ia7aYe1cpNg4QYnn",
@@ -351,34 +200,16 @@ func TestQtumDecodeToBytes(t *testing.T) {
 			output: "00143420312df19e36fe37af531a75f183b3f282b862",
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := toBytesMap[slip44.QTUM](tt.input)
-			if tt.err != nil {
-				if err.Error() != tt.err.Error() {
-					t.Errorf("BitcoinDecodeToBytes() error = %v, wantErr %v", err, tt.err)
-					return
-				}
-			} else {
-				if !reflect.DeepEqual(hex.EncodeToString(got), tt.output) {
-					t.Errorf("BitcoinDecodeToBytes() = %v, want %v, err: %v", hex.EncodeToString(got), tt.output, tt.err)
-				}
-			}
-		})
-	}
+
+	RunTestsEncode(t, slip44.QTUM, tests)
 }
 
-func TestQtumEncodeToString(t *testing.T) {
-	script1, _ := hex.DecodeString("76a91480485018e46a9c8176282adf0acb4ff3e0de93ff88ac")
-	script2, _ := hex.DecodeString("a9146b85b3dac9340f36b9d32bbacf2ffcb0851ef17987")
-	script3, _ := hex.DecodeString("00143420312df19e36fe37af531a75f183b3f282b862")
+func TestQtumDecodeToString(t *testing.T) {
+	script1 := "76a91480485018e46a9c8176282adf0acb4ff3e0de93ff88ac"
+	script2 := "a9146b85b3dac9340f36b9d32bbacf2ffcb0851ef17987"
+	script3 := "00143420312df19e36fe37af531a75f183b3f282b862"
 
-	tests := []struct {
-		name   string
-		input  []byte
-		output string
-		err    error
-	}{
+	tests := []TestcaseDecode {
 		{
 			name:   "P2PKH",
 			input:  script1,
@@ -395,30 +226,12 @@ func TestQtumEncodeToString(t *testing.T) {
 			output: "qc1qxssrzt03ncm0uda02vd8tuvrk0eg9wrz8qm2qe",
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := toStringMap[slip44.QTUM](tt.input)
-			if tt.err != nil {
-				if err.Error() != tt.err.Error() {
-					t.Errorf("BitcoinEncodeToString() error = %v, wantErr %v", err, tt.err)
-					return
-				}
-			} else {
-				if got != tt.output {
-					t.Errorf("BitcoinEncodeToString() = %v, want %v", got, tt.output)
-				}
-			}
-		})
-	}
+
+	RunTestsDecode(t, slip44.QTUM, tests)
 }
 
-func TestVIADecodeToBytes(t *testing.T) {
-	tests := []struct {
-		name   string
-		input  string
-		output string
-		err    error
-	}{
+func TestVIAEncodeToBytes(t *testing.T) {
+	tests := []TestcaseEncode {
 		{
 			name:   "P2PKH",
 			input:  "Vw6bJFaF5Hyiveko7dpqRjVvcTAsjz7eYa",
@@ -435,34 +248,16 @@ func TestVIADecodeToBytes(t *testing.T) {
 			output: "001484542436f952c22c4c54a0fcd2c997c66317ea30",
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := toBytesMap[slip44.VIACOIN](tt.input)
-			if tt.err != nil {
-				if err.Error() != tt.err.Error() {
-					t.Errorf("BitcoinDecodeToBytes() error = %v, wantErr %v", err, tt.err)
-					return
-				}
-			} else {
-				if !reflect.DeepEqual(hex.EncodeToString(got), tt.output) {
-					t.Errorf("BitcoinDecodeToBytes() = %v, want %v, err: %v", hex.EncodeToString(got), tt.output, tt.err)
-				}
-			}
-		})
-	}
+
+	RunTestsEncode(t, slip44.VIACOIN, tests)	
 }
 
-func TestVIAEncodeToString(t *testing.T) {
-	script1, _ := hex.DecodeString("76a914e771c6695c5dd189ccc4ef00cd0f3db3096d79bd88ac")
-	script2, _ := hex.DecodeString("a9146b85b3dac9340f36b9d32bbacf2ffcb0851ef17987")
-	script3, _ := hex.DecodeString("001484542436f952c22c4c54a0fcd2c997c66317ea30")
+func TestVIADecodeToString(t *testing.T) {
+	script1 := "76a914e771c6695c5dd189ccc4ef00cd0f3db3096d79bd88ac"
+	script2 := "a9146b85b3dac9340f36b9d32bbacf2ffcb0851ef17987"
+	script3 := "001484542436f952c22c4c54a0fcd2c997c66317ea30"
 
-	tests := []struct {
-		name   string
-		input  []byte
-		output string
-		err    error
-	}{
+	tests := []TestcaseDecode {
 		{
 			name:   "P2PKH",
 			input:  script1,
@@ -479,30 +274,12 @@ func TestVIAEncodeToString(t *testing.T) {
 			output: "via1qs32zgdhe2tpzcnz55r7d9jvhce33063s8w4xre",
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := toStringMap[slip44.VIACOIN](tt.input)
-			if tt.err != nil {
-				if err.Error() != tt.err.Error() {
-					t.Errorf("BitcoinEncodeToString() error = %v, wantErr %v", err, tt.err)
-					return
-				}
-			} else {
-				if got != tt.output {
-					t.Errorf("BitcoinEncodeToString() = %v, want %v", got, tt.output)
-				}
-			}
-		})
-	}
+
+	RunTestsDecode(t, slip44.VIACOIN, tests)
 }
 
-func TestDigiByteDecodeToBytes(t *testing.T) {
-	tests := []struct {
-		name   string
-		input  string
-		output string
-		err    error
-	}{
+func TestDigiByteEncodeToBytes(t *testing.T) {
+	tests := []TestcaseEncode {
 		{
 			name:   "P2PKH",
 			input:  "DBfCffUdSbhqKZhjuvrJ6AgvJofT4E2kp4",
@@ -519,34 +296,16 @@ func TestDigiByteDecodeToBytes(t *testing.T) {
 			output: "0014885534ab5dc680b68d95c0af49ec2acc2e9915c4",
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := toBytesMap[slip44.DIGIBYTE](tt.input)
-			if tt.err != nil {
-				if err.Error() != tt.err.Error() {
-					t.Errorf("BitcoinDecodeToBytes() error = %v, wantErr %v", err, tt.err)
-					return
-				}
-			} else {
-				if !reflect.DeepEqual(hex.EncodeToString(got), tt.output) {
-					t.Errorf("BitcoinDecodeToBytes() = %v, want %v, err: %v", hex.EncodeToString(got), tt.output, tt.err)
-				}
-			}
-		})
-	}
+
+	RunTestsEncode(t, slip44.DIGIBYTE, tests)	
 }
 
-func TestDigiByteEncodeToString(t *testing.T) {
-	script1, _ := hex.DecodeString("76a91447825943ca6a936b177fdc7c9dc05251640169c288ac")
-	script2, _ := hex.DecodeString("a91452356ed3d2d31eb8b263ace5d164e3cf3b37096687")
-	script3, _ := hex.DecodeString("0014885534ab5dc680b68d95c0af49ec2acc2e9915c4")
+func TestDigiByteDecodeToString(t *testing.T) {
+	script1 := "76a91447825943ca6a936b177fdc7c9dc05251640169c288ac"
+	script2 := "a91452356ed3d2d31eb8b263ace5d164e3cf3b37096687"
+	script3 := "0014885534ab5dc680b68d95c0af49ec2acc2e9915c4"
 
-	tests := []struct {
-		name   string
-		input  []byte
-		output string
-		err    error
-	}{
+	tests := []TestcaseDecode {
 		{
 			name:   "P2PKH",
 			input:  script1,
@@ -563,30 +322,12 @@ func TestDigiByteEncodeToString(t *testing.T) {
 			output: "dgb1q3p2nf26ac6qtdrv4czh5nmp2eshfj9wyn9vv3d",
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := toStringMap[slip44.DIGIBYTE](tt.input)
-			if tt.err != nil {
-				if err.Error() != tt.err.Error() {
-					t.Errorf("BitcoinEncodeToString() error = %v, wantErr %v", err, tt.err)
-					return
-				}
-			} else {
-				if got != tt.output {
-					t.Errorf("BitcoinEncodeToString() = %v, want %v", got, tt.output)
-				}
-			}
-		})
-	}
+
+	RunTestsDecode(t, slip44.DIGIBYTE, tests)
 }
 
-func TestZcoinDecodeToBytes(t *testing.T) {
-	tests := []struct {
-		name   string
-		input  string
-		output string
-		err    error
-	}{
+func TestZcoinEncodeToBytes(t *testing.T) {
+	tests := []TestcaseEncode {
 		{
 			name:   "P2PKH",
 			input:  "a4YtT82mWWxHZhLmdx7e5aroW92dqJoRs3",
@@ -598,33 +339,15 @@ func TestZcoinDecodeToBytes(t *testing.T) {
 			output: "a914f010b17a9189e0f2737d71ae9790359eb5bbc13787",
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := toBytesMap[slip44.ZCOIN](tt.input)
-			if tt.err != nil {
-				if err.Error() != tt.err.Error() {
-					t.Errorf("BitcoinDecodeToBytes() error = %v, wantErr %v", err, tt.err)
-					return
-				}
-			} else {
-				if !reflect.DeepEqual(hex.EncodeToString(got), tt.output) {
-					t.Errorf("BitcoinDecodeToBytes() = %v, want %v, err: %v", hex.EncodeToString(got), tt.output, tt.err)
-				}
-			}
-		})
-	}
+
+	RunTestsEncode(t, slip44.ZCOIN, tests)
 }
 
-func TestZcoinEncodeToString(t *testing.T) {
-	script1, _ := hex.DecodeString("76a9142a10f88e30768d2712665c279922b9621ce58bc788ac")
-	script2, _ := hex.DecodeString("a914f010b17a9189e0f2737d71ae9790359eb5bbc13787")
+func TestZcoinDecodeToString(t *testing.T) {
+	script1 := "76a9142a10f88e30768d2712665c279922b9621ce58bc788ac"
+	script2 := "a914f010b17a9189e0f2737d71ae9790359eb5bbc13787"
 
-	tests := []struct {
-		name   string
-		input  []byte
-		output string
-		err    error
-	}{
+	tests := []TestcaseDecode {
 		{
 			name:   "P2PKH",
 			input:  script1,
@@ -636,30 +359,12 @@ func TestZcoinEncodeToString(t *testing.T) {
 			output: "4CFa4fnAQvFz4VpikGNzQ9XfCDXMmdk6sh",
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := toStringMap[slip44.ZCOIN](tt.input)
-			if tt.err != nil {
-				if err.Error() != tt.err.Error() {
-					t.Errorf("BitcoinEncodeToString() error = %v, wantErr %v", err, tt.err)
-					return
-				}
-			} else {
-				if got != tt.output {
-					t.Errorf("BitcoinEncodeToString() = %v, want %v", got, tt.output)
-				}
-			}
-		})
-	}
+
+	RunTestsDecode(t, slip44.ZCOIN, tests)
 }
 
-func TestRavenDecodeToBytes(t *testing.T) {
-	tests := []struct {
-		name   string
-		input  string
-		output string
-		err    error
-	}{
+func TestRavenEncodeToBytes(t *testing.T) {
+	tests := []TestcaseEncode {
 		{
 			name:   "P2PKH",
 			input:  "RNoSGCX8SPFscj8epDaJjqEpuZa2B5in88",
@@ -671,33 +376,15 @@ func TestRavenDecodeToBytes(t *testing.T) {
 			output: "a914bd92088bb7e82d611a9b94fbb74a0908152b784f87",
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := toBytesMap[slip44.RAVENCOIN](tt.input)
-			if tt.err != nil {
-				if err.Error() != tt.err.Error() {
-					t.Errorf("BitcoinDecodeToBytes() error = %v, wantErr %v", err, tt.err)
-					return
-				}
-			} else {
-				if !reflect.DeepEqual(hex.EncodeToString(got), tt.output) {
-					t.Errorf("BitcoinDecodeToBytes() = %v, want %v, err: %v", hex.EncodeToString(got), tt.output, tt.err)
-				}
-			}
-		})
-	}
+
+	RunTestsEncode(t, slip44.RAVENCOIN, tests)
 }
 
-func TestRavenEncodeToString(t *testing.T) {
-	script1, _ := hex.DecodeString("76a9149451f4546e09fc2e49ef9b5303924712ec2b038e88ac")
-	script2, _ := hex.DecodeString("a914bd92088bb7e82d611a9b94fbb74a0908152b784f87")
+func TestRavenDecodeToString(t *testing.T) {
+	script1 := "76a9149451f4546e09fc2e49ef9b5303924712ec2b038e88ac"
+	script2 := "a914bd92088bb7e82d611a9b94fbb74a0908152b784f87"
 
-	tests := []struct {
-		name   string
-		input  []byte
-		output string
-		err    error
-	}{
+	tests := []TestcaseDecode {
 		{
 			name:   "P2PKH",
 			input:  script1,
@@ -709,19 +396,6 @@ func TestRavenEncodeToString(t *testing.T) {
 			output: "rPWwn5h4QFZNaz1XmY39rc73sdYGGDdmq1",
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := toStringMap[slip44.RAVENCOIN](tt.input)
-			if tt.err != nil {
-				if err.Error() != tt.err.Error() {
-					t.Errorf("BitcoinEncodeToString() error = %v, wantErr %v", err, tt.err)
-					return
-				}
-			} else {
-				if got != tt.output {
-					t.Errorf("BitcoinEncodeToString() = %v, want %v", got, tt.output)
-				}
-			}
-		})
-	}
+
+	RunTestsDecode(t, slip44.RAVENCOIN, tests)
 }

--- a/bitcoin_test.go
+++ b/bitcoin_test.go
@@ -69,7 +69,7 @@ func TestBitcoinDecodeToString(t *testing.T) {
 		{
 			name:  "Empty",
 			input: "",
-			err:   errors.New("empty input"),
+			err:   errors.New("invalid data length"),
 		},
 		{
 			name:  "Wrong script",

--- a/bitcoin_test.go
+++ b/bitcoin_test.go
@@ -47,7 +47,7 @@ func TestBitcoinEncodeToBytes(t *testing.T) {
 		{
 			name:  "Empty",
 			input: "",
-			err:   errors.New("empty input"),
+			err:   errors.New("invalid address"),
 		},
 		{
 			name:  "Ethereum",

--- a/bitcoin_test.go
+++ b/bitcoin_test.go
@@ -1,20 +1,14 @@
 package coincodec
 
 import (
-	"encoding/hex"
-	"reflect"
 	"testing"
 
 	"github.com/pkg/errors"
+	"github.com/wealdtech/go-slip44"
 )
 
-func TestBitcoinDecodeToBytes(t *testing.T) {
-	tests := []struct {
-		name   string
-		input  string
-		output string
-		err    error
-	}{
+func TestBitcoinEncodeToBytes(t *testing.T) {
+	tests := []TestcaseEncode {
 		{
 			name:   "P2PKH",
 			input:  "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa",
@@ -53,7 +47,7 @@ func TestBitcoinDecodeToBytes(t *testing.T) {
 		{
 			name:  "Empty",
 			input: "",
-			err:   errors.New("invalid address"),
+			err:   errors.New("empty input"),
 		},
 		{
 			name:  "Ethereum",
@@ -61,48 +55,25 @@ func TestBitcoinDecodeToBytes(t *testing.T) {
 			err:   errors.New("decoding bech32 failed: invalid index of 1"),
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := BitcoinDecodeToBytes(tt.input)
-			if tt.err != nil {
-				if err.Error() != tt.err.Error() {
-					t.Errorf("BitcoinDecodeToBytes() error = %v, wantErr %v", err, tt.err)
-					return
-				}
-			} else {
-				if !reflect.DeepEqual(hex.EncodeToString(got), tt.output) {
-					t.Errorf("BitcoinDecodeToBytes() = %v, want %v, err: %v", hex.EncodeToString(got), tt.output, tt.err)
-				}
-			}
-		})
-	}
+
+	RunTestsEncode(t, slip44.BITCOIN, tests)
 }
 
-func TestBitcoinEncodeToString(t *testing.T) {
-	script1, _ := hex.DecodeString("76a91462e907b15cbf27d5425399ebf6f0fb50ebb88f1888ac")
-	script2, _ := hex.DecodeString("a91462e907b15cbf27d5425399ebf6f0fb50ebb88f1887")
-	script3, _ := hex.DecodeString("0014751e76e8199196d454941c45d1b3a323f1433bd6")
-	script4, _ := hex.DecodeString("00201863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262")
+func TestBitcoinDecodeToString(t *testing.T) {
+	script1 := "76a91462e907b15cbf27d5425399ebf6f0fb50ebb88f1888ac"
+	script2 := "a91462e907b15cbf27d5425399ebf6f0fb50ebb88f1887"
+	script3 := "0014751e76e8199196d454941c45d1b3a323f1433bd6"
+	script4 := "00201863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262"
 
-	tests := []struct {
-		name   string
-		input  []byte
-		output string
-		err    error
-	}{
-		{
-			name:  "Nil",
-			input: nil,
-			err:   errors.New("invalid data length"),
-		},
+	tests := []TestcaseDecode {
 		{
 			name:  "Empty",
-			input: []byte{},
-			err:   errors.New("invalid data length"),
+			input: "",
+			err:   errors.New("empty input"),
 		},
 		{
 			name:  "Wrong script",
-			input: []byte{0x00, 0x14, 0x01, 0x2},
+			input: "00140102",
 			err:   errors.New("wrong script data"),
 		},
 		{
@@ -126,19 +97,6 @@ func TestBitcoinEncodeToString(t *testing.T) {
 			output: "bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3",
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := BitcoinEncodeToString(tt.input)
-			if tt.err != nil {
-				if err.Error() != tt.err.Error() {
-					t.Errorf("BitcoinEncodeToString() error = %v, wantErr %v", err, tt.err)
-					return
-				}
-			} else {
-				if got != tt.output {
-					t.Errorf("BitcoinEncodeToString() = %v, want %v", got, tt.output)
-				}
-			}
-		})
-	}
+
+	RunTestsDecode(t, slip44.BITCOIN, tests)
 }

--- a/bnb_test.go
+++ b/bnb_test.go
@@ -40,7 +40,7 @@ func TestBNBDecodeToString(t *testing.T) {
 		{
 			name:  "Empty",
 			input: "",
-			err:   errors.New("empty input"),
+			err:   errors.New("A Bech32 address key hash must be 20 bytes"),
 		},
 		{
 			name:  "Too short",

--- a/bnb_test.go
+++ b/bnb_test.go
@@ -1,20 +1,14 @@
 package coincodec
 
 import (
-	"encoding/hex"
-	"reflect"
 	"testing"
 
 	"github.com/pkg/errors"
+	"github.com/wealdtech/go-slip44"
 )
 
-func TestBNBDecodeToBytes(t *testing.T) {
-	tests := []struct {
-		name   string
-		input  string
-		output string
-		err    error
-	}{
+func TestBNBEncodeToBytes(t *testing.T) {
+	tests := []TestcaseEncode {
 		{
 			name:   "Normal",
 			input:  "bnb1grpf0955h0ykzq3ar5nmum7y6gdfl6lxfn46h2",
@@ -36,39 +30,21 @@ func TestBNBDecodeToBytes(t *testing.T) {
 			err:   errors.New("A Bech32 address key hash must be 20 bytes"),
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := BNBDecodeToBytes(tt.input)
-			if tt.err != nil {
-				if err.Error() != tt.err.Error() {
-					t.Errorf("BNBDecodeToBytes() error = %v, wantErr %v", err, tt.err)
-					return
-				}
-			} else {
-				if !reflect.DeepEqual(hex.EncodeToString(got), tt.output) {
-					t.Errorf("BNBDecodeToBytes() = %v, want %v", hex.EncodeToString(got), tt.output)
-				}
-			}
-		})
-	}
+
+	RunTestsEncode(t, slip44.BINANCE, tests)
 }
 
-func TestBNBEncodeToString(t *testing.T) {
-	keyhash, _ := hex.DecodeString("40c2979694bbc961023d1d27be6fc4d21a9febe6")
-	tests := []struct {
-		name   string
-		input  []byte
-		output string
-		err    error
-	}{
-		{
-			name:  "Nil",
-			input: nil,
-			err:   errors.New("A Bech32 address key hash must be 20 bytes"),
-		},
+func TestBNBDecodeToString(t *testing.T) {
+	keyhash := "40c2979694bbc961023d1d27be6fc4d21a9febe6"
+	tests := []TestcaseDecode {
 		{
 			name:  "Empty",
-			input: []byte{},
+			input: "",
+			err:   errors.New("empty input"),
+		},
+		{
+			name:  "Too short",
+			input: "0102030405",
 			err:   errors.New("A Bech32 address key hash must be 20 bytes"),
 		},
 		{
@@ -77,19 +53,6 @@ func TestBNBEncodeToString(t *testing.T) {
 			output: "bnb1grpf0955h0ykzq3ar5nmum7y6gdfl6lxfn46h2",
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := BNBEncodeToString(tt.input)
-			if tt.err != nil {
-				if err.Error() != tt.err.Error() {
-					t.Errorf("BNBEncodeToString() error = %v, wantErr %v", err, tt.err)
-					return
-				}
-			} else {
-				if got != tt.output {
-					t.Errorf("BNBEncodeToString() = %v, want %v", got, tt.output)
-				}
-			}
-		})
-	}
+
+	RunTestsDecode(t, slip44.BINANCE, tests)
 }

--- a/codec.go
+++ b/codec.go
@@ -23,7 +23,7 @@ var toStringMap = make(map[uint32]func([]byte) (string, error))
 // ToBytes converts the input string to a byte array for the given coin type.
 func ToBytes(input string, coinType uint32) ([]byte, error) {
 	if len(input) == 0 {
-		return nil, errors.New("no input")
+		return nil, errors.New("empty input")
 	}
 	f, exists := toBytesMap[coinType]
 	if !exists {
@@ -34,8 +34,8 @@ func ToBytes(input string, coinType uint32) ([]byte, error) {
 
 // ToString converts the input byte array to a string representation of the given coin type.
 func ToString(input []byte, coinType uint32) (string, error) {
-	if len(input) == 0 {
-		return "", errors.New("no input")
+	if input == nil || len(input) == 0 {
+		return "", errors.New("empty input")
 	}
 	f, exists := toStringMap[coinType]
 	if !exists {

--- a/codec_test.go
+++ b/codec_test.go
@@ -33,7 +33,7 @@ func TestToBytes(t *testing.T) {
 			name:     "Empty",
 			input:    "",
 			coinType: slip44.ETHER,
-			err:      errors.New("no input"),
+			err:      errors.New("empty input"),
 		},
 		{
 			name:     "Unknown",
@@ -84,13 +84,13 @@ func TestToString(t *testing.T) {
 			name:     "Nil",
 			input:    nil,
 			coinType: slip44.ETHER,
-			err:      errors.New("no input"),
+			err:      errors.New("empty input"),
 		},
 		{
 			name:     "Empty",
 			input:    []byte{},
 			coinType: slip44.ETHER,
-			err:      errors.New("no input"),
+			err:      errors.New("empty input"),
 		},
 		{
 			name:     "Unknown",

--- a/cosmos_test.go
+++ b/cosmos_test.go
@@ -1,20 +1,14 @@
 package coincodec
 
 import (
-	"encoding/hex"
-	"reflect"
 	"testing"
 
 	"github.com/pkg/errors"
+	"github.com/wealdtech/go-slip44"
 )
 
-func TestCosmosDecodeToBytes(t *testing.T) {
-	tests := []struct {
-		name   string
-		input  string
-		output string
-		err    error
-	}{
+func TestCosmosEncodeToBytes(t *testing.T) {
+	tests := []TestcaseEncode {
 		{
 			name:   "Normal",
 			input:  "cosmos1hsk6jryyqjfhp5dhc55tc9jtckygx0eph6dd02",
@@ -41,41 +35,23 @@ func TestCosmosDecodeToBytes(t *testing.T) {
 			err:   errors.New("A Bech32 address key hash must be 20 bytes"),
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := CosmosDecodeToBytes(tt.input)
-			if tt.err != nil {
-				if err.Error() != tt.err.Error() {
-					t.Errorf("CosmosDecodeToBytes() error = %v, wantErr %v", err, tt.err)
-					return
-				}
-			} else {
-				if !reflect.DeepEqual(hex.EncodeToString(got), tt.output) {
-					t.Errorf("CosmosDecodeToBytes() = %v, want %v", hex.EncodeToString(got), tt.output)
-				}
-			}
-		})
-	}
+
+	RunTestsEncode(t, slip44.ATOM, tests)
 }
 
-func TestCosmosEncodeToString(t *testing.T) {
-	keyhash, _ := hex.DecodeString("bc2da90c84049370d1b7c528bc164bc588833f21")
-	keyhash2, _ := hex.DecodeString("6e436a571cec916167ba105160474b9c9cd132bd")
+func TestCosmosDecodeToString(t *testing.T) {
+	keyhash := "bc2da90c84049370d1b7c528bc164bc588833f21"
+	keyhash2 := "6e436a571cec916167ba105160474b9c9cd132bd"
 
-	tests := []struct {
-		name   string
-		input  []byte
-		output string
-		err    error
-	}{
-		{
-			name:  "Nil",
-			input: nil,
-			err:   errors.New("A Bech32 address key hash must be 20 bytes"),
-		},
+	tests := []TestcaseDecode {
 		{
 			name:  "Empty",
-			input: []byte{},
+			input: "",
+			err:   errors.New("empty input"),
+		},
+		{
+			name:  "Too short",
+			input: "0102030405",
 			err:   errors.New("A Bech32 address key hash must be 20 bytes"),
 		},
 		{
@@ -89,19 +65,6 @@ func TestCosmosEncodeToString(t *testing.T) {
 			output: "cosmos1depk54cuajgkzea6zpgkq36tnjwdzv4afc3d27",
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := CosmosEncodeToString(tt.input)
-			if tt.err != nil {
-				if err.Error() != tt.err.Error() {
-					t.Errorf("CosmosEncodeToString() error = %v, wantErr %v", err, tt.err)
-					return
-				}
-			} else {
-				if got != tt.output {
-					t.Errorf("CosmosEncodeToString() = %v, want %v", got, tt.output)
-				}
-			}
-		})
-	}
+
+	RunTestsDecode(t, slip44.ATOM, tests)
 }

--- a/cosmos_test.go
+++ b/cosmos_test.go
@@ -47,7 +47,7 @@ func TestCosmosDecodeToString(t *testing.T) {
 		{
 			name:  "Empty",
 			input: "",
-			err:   errors.New("empty input"),
+			err:   errors.New("A Bech32 address key hash must be 20 bytes"),
 		},
 		{
 			name:  "Too short",

--- a/ethereum_test.go
+++ b/ethereum_test.go
@@ -72,7 +72,7 @@ func TestEtherToString(t *testing.T) {
 		{
 			name:  "Empty",
 			input: "",
-			err:   errors.New("empty input"),
+			err:   errors.New("Ethereum address must have 20 bytes"),
 		},
 		{
 			name:  "Too short",

--- a/ethereum_test.go
+++ b/ethereum_test.go
@@ -25,7 +25,7 @@ func TestEtherToBytes(t *testing.T) {
 		{
 			name:  "Empty",
 			input: "",
-			err:   errors.New("empty input"),
+			err:   errors.New("Ethereum address must have 40 characters"),
 		},
 		{
 			name:  "Blank",

--- a/ethereum_test.go
+++ b/ethereum_test.go
@@ -14,22 +14,18 @@
 package coincodec
 
 import (
-	"bytes"
 	"errors"
 	"testing"
+
+	"github.com/wealdtech/go-slip44"
 )
 
 func TestEtherToBytes(t *testing.T) {
-	tests := []struct {
-		name   string
-		input  string
-		output []byte
-		err    error
-	}{
+	tests := []TestcaseEncode {
 		{
 			name:  "Empty",
 			input: "",
-			err:   errors.New("Ethereum address must have 40 characters"),
+			err:   errors.New("empty input"),
 		},
 		{
 			name:  "Blank",
@@ -64,76 +60,31 @@ func TestEtherToBytes(t *testing.T) {
 		{
 			name:   "Good",
 			input:  "0x0102030405060708090a0B0c0d0e0f1011121314",
-			output: []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14},
+			output: "0102030405060708090a0b0c0d0e0f1011121314",
 		},
 	}
 
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			output, err := EtherToBytes(test.input)
-			if test.err != nil {
-				if err == nil {
-					t.Fatalf("Missing expected error: expected %v", test.err)
-				}
-				if test.err.Error() != err.Error() {
-					t.Fatalf("Unexpected error value: expected %v, received %v", test.err, err)
-				}
-			} else {
-				if err != nil {
-					t.Fatalf("Unexpected error: %v", err)
-				}
-				if !bytes.Equal(test.output, output) {
-					t.Fatalf("Unexpected output: expected %x, received %x", test.output, output)
-				}
-			}
-		})
-
-	}
+	RunTestsEncode(t, slip44.ETHER, tests)
 }
 
 func TestEtherToString(t *testing.T) {
-	tests := []struct {
-		name   string
-		input  []byte
-		output string
-		err    error
-	}{
-		{
-			name:  "Nil",
-			input: nil,
-			err:   errors.New("Ethereum address must have 20 bytes"),
-		},
+	tests := []TestcaseDecode {
 		{
 			name:  "Empty",
-			input: []byte{},
+			input: "",
+			err:   errors.New("empty input"),
+		},
+		{
+			name:  "Too short",
+			input: "0102030405",
 			err:   errors.New("Ethereum address must have 20 bytes"),
 		},
 		{
 			name:   "Good",
-			input:  []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14},
+			input: "0102030405060708090a0b0c0d0e0f1011121314",
 			output: "0x0102030405060708090a0B0c0d0e0f1011121314",
 		},
 	}
 
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			output, err := EtherToString(test.input)
-			if test.err != nil {
-				if err == nil {
-					t.Fatalf("Missing expected error: expected %v", test.err)
-				}
-				if test.err.Error() != err.Error() {
-					t.Fatalf("Unexpected error value: expected %v, received %v", test.err, err)
-				}
-			} else {
-				if err != nil {
-					t.Fatalf("Unexpected error: %v", err)
-				}
-				if test.output != output {
-					t.Fatalf("Unexpected output: expected %x, received %x", test.output, output)
-				}
-			}
-		})
-
-	}
+	RunTestsDecode(t, slip44.ETHER, tests)
 }

--- a/iotex_test.go
+++ b/iotex_test.go
@@ -1,69 +1,33 @@
 package coincodec
 
 import (
-	"encoding/hex"
-	"reflect"
 	"testing"
+
+	"github.com/wealdtech/go-slip44"
 )
 
-func TestIoTexDecodeToBytes(t *testing.T) {
-	tests := []struct {
-		name   string
-		input  string
-		output string
-		err    error
-	}{
+func TestIoTexEncodeToBytes(t *testing.T) {
+	tests := []TestcaseEncode {
 		{
 			name:   "Normal",
 			input:  "io187wzp08vnhjjpkydnr97qlh8kh0dpkkytfam8j",
 			output: "3f9c20bcec9de520d88d98cbe07ee7b5ded0dac4",
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := IoTexDecodeToBytes(tt.input)
-			if tt.err != nil {
-				if err.Error() != tt.err.Error() {
-					t.Errorf("IoTexDecodeToBytes() error = %v, wantErr %v", err, tt.err)
-					return
-				}
-			} else {
-				if !reflect.DeepEqual(hex.EncodeToString(got), tt.output) {
-					t.Errorf("IoTexDecodeToBytes() = %v, want %v", hex.EncodeToString(got), tt.output)
-				}
-			}
-		})
-	}
+
+	RunTestsEncode(t, slip44.IOTEX, tests)
 }
 
-func TestIoTexEncodeToString(t *testing.T) {
-	keyhash, _ := hex.DecodeString("3f9c20bcec9de520d88d98cbe07ee7b5ded0dac4")
+func TestIoTexDecodeToString(t *testing.T) {
+	keyhash := "3f9c20bcec9de520d88d98cbe07ee7b5ded0dac4"
 
-	tests := []struct {
-		name   string
-		input  []byte
-		output string
-		err    error
-	}{
+	tests := []TestcaseDecode {
 		{
 			name:   "Good",
 			input:  keyhash,
 			output: "io187wzp08vnhjjpkydnr97qlh8kh0dpkkytfam8j",
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := IoTexEncodeToString(tt.input)
-			if tt.err != nil {
-				if err.Error() != tt.err.Error() {
-					t.Errorf("IoTexEncodeToString() error = %v, wantErr %v", err, tt.err)
-					return
-				}
-			} else {
-				if got != tt.output {
-					t.Errorf("IoTexEncodeToString() = %v, want %v", got, tt.output)
-				}
-			}
-		})
-	}
+
+	RunTestsDecode(t, slip44.IOTEX, tests)
 }

--- a/stellar_test.go
+++ b/stellar_test.go
@@ -1,21 +1,14 @@
 package coincodec
 
 import (
-	"encoding/hex"
-	"reflect"
-	"strings"
 	"testing"
 
 	"github.com/pkg/errors"
+	"github.com/wealdtech/go-slip44"
 )
 
-func TestStellarDecodeToBytes(t *testing.T) {
-	tests := []struct {
-		name   string
-		input  string
-		output string
-		err    error
-	}{
+func TestStellarEncodeToBytes(t *testing.T) {
+	tests := []TestcaseEncode {
 		{
 			name:   "Normal",
 			input:  "GAI3GJ2Q3B35AOZJ36C4ANE3HSS4NK7WI6DNO4ZSHRAX6NG7BMX6VJER",
@@ -37,51 +30,20 @@ func TestStellarDecodeToBytes(t *testing.T) {
 			err:   errors.New("wrong checksum"),
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := StellarDecodeToBytes(tt.input)
-			if tt.err != nil {
-				if !strings.HasPrefix(err.Error(), tt.err.Error()) {
-					t.Errorf("StellarDecodeToBytes() error = %v, wantErr %v", err, tt.err)
-					return
-				}
-			} else {
-				if !reflect.DeepEqual(hex.EncodeToString(got), tt.output) {
-					t.Errorf("StellarDecodeToBytes() = %v, want %v", hex.EncodeToString(got), tt.output)
-				}
-			}
-		})
-	}
+
+	RunTestsEncode(t, slip44.STELLAR_LUMENS, tests)
 }
 
-func TestStellarEncodeToString(t *testing.T) {
-	pubkey, _ := hex.DecodeString("11b32750d877d03b29df85c0349b3ca5c6abf64786d773323c417f34df0b2fea")
+func TestStellarDecodeToString(t *testing.T) {
+	pubkey := "11b32750d877d03b29df85c0349b3ca5c6abf64786d773323c417f34df0b2fea"
 
-	tests := []struct {
-		name   string
-		input  []byte
-		output string
-		err    error
-	}{
+	tests := []TestcaseDecode {
 		{
 			name:   "Good",
 			input:  pubkey,
 			output: "GAI3GJ2Q3B35AOZJ36C4ANE3HSS4NK7WI6DNO4ZSHRAX6NG7BMX6VJER",
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := StellarEncodeToString(tt.input)
-			if tt.err != nil {
-				if err.Error() != tt.err.Error() {
-					t.Errorf("StellarEncodeToString() error = %v, wantErr %v", err, tt.err)
-					return
-				}
-			} else {
-				if got != tt.output {
-					t.Errorf("StellarEncodeToString() = %v, want %v", got, tt.output)
-				}
-			}
-		})
-	}
+
+	RunTestsDecode(t, slip44.STELLAR_LUMENS, tests)
 }

--- a/test_runner.go
+++ b/test_runner.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"testing"
 	"strings"
+	"fmt"
 )
 
 type TestcaseEncode struct {
@@ -24,52 +25,64 @@ type TestcaseDecode struct {
 func RunTestsEncode(t *testing.T, coinType uint32, tests []TestcaseEncode) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			testfun, _ := toBytesMap[coinType]
-
-			got, err := testfun(tt.input)
-
-			var goterror string = "(no error)"
-			if err != nil { goterror = err.Error() }
-			if tt.err != nil {
-				if !strings.HasPrefix(goterror, err.Error()) {
-				//if goterror != tt.err.Error() {
-					t.Errorf("%v %v: ToBytes() error = %v, wantErr %v", coinType, tt.name, goterror, tt.err)
-					return
-				}
-			} else {
-				gothex := hex.EncodeToString(got)
-				if !reflect.DeepEqual(gothex, tt.output) {
-					t.Errorf("%v %v: ToBytes() = %v, want %v, err: %v", coinType, tt.name, gothex, tt.output, tt.err)
-				}
+			err := RunTestEncode(coinType, tt)
+			if err != nil {
+				t.Error(err.Error())
 			}
 		})
 	}
 }
 
+func RunTestEncode(coinType uint32, tt TestcaseEncode) (error) {
+	testfun, _ := toBytesMap[coinType]
+
+	got, err := testfun(tt.input)
+
+	var goterror string = "(no error)"
+	if err != nil { goterror = err.Error() }
+	if tt.err != nil {
+		if !strings.HasPrefix(goterror, tt.err.Error()) {
+			return fmt.Errorf("%v %v: ToBytes() error = %v, wantErr %v", coinType, tt.name, goterror, tt.err)
+		}
+	} else {
+		gothex := hex.EncodeToString(got)
+		if !reflect.DeepEqual(gothex, tt.output) {
+			return fmt.Errorf("%v %v: ToBytes() = %v, want %v, err: %v", coinType, tt.name, gothex, tt.output, tt.err)
+		}
+	}
+	return nil
+}
+
 func RunTestsDecode(t *testing.T, coinType uint32, tests []TestcaseDecode) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			decoded, err := hex.DecodeString(tt.input)
+			err := RunTestDecode(coinType, tt)
 			if err != nil {
-				t.Errorf("%v %v: Preparation error, input is not valid hex string err %v input %v", coinType, tt.name, err, tt.input)
-				return
-			}
-			testfun, _ := toStringMap[coinType]
-
-			got, err := testfun(decoded)
-
-			var goterror string = "(no error)"
-			if err != nil { goterror = err.Error() }
-			if tt.err != nil {
-				if goterror != tt.err.Error() {
-					t.Errorf("%v %v: ToString() error = %v, wantErr %v", coinType, tt.name, goterror, tt.err)
-					return
-				}
-			} else {
-				if got != tt.output {
-					t.Errorf("%v %v: ToString() = %v, want %v, err: %v", coinType, tt.name, got, tt.output, goterror)
-				}
+				t.Error(err.Error())
 			}
 		})
 	}
+}
+
+func RunTestDecode(coinType uint32, tt TestcaseDecode) (error) {
+	decoded, err := hex.DecodeString(tt.input)
+	if err != nil {
+		return fmt.Errorf("%v %v: Preparation error, input is not valid hex string err %v input %v", coinType, tt.name, err, tt.input)
+	}
+	testfun, _ := toStringMap[coinType]
+
+	got, err := testfun(decoded)
+
+	var goterror string = "(no error)"
+	if err != nil { goterror = err.Error() }
+	if tt.err != nil {
+		if goterror != tt.err.Error() {
+			return fmt.Errorf("%v %v: ToString() error = %v, wantErr %v", coinType, tt.name, goterror, tt.err)
+		}
+	} else {
+		if got != tt.output {
+			return fmt.Errorf("%v %v: ToString() = %v, want %v, err: %v", coinType, tt.name, got, tt.output, goterror)
+		}
+	}
+	return nil
 }

--- a/test_runner.go
+++ b/test_runner.go
@@ -24,7 +24,10 @@ type TestcaseDecode struct {
 func RunTestsEncode(t *testing.T, coinType uint32, tests []TestcaseEncode) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ToBytes(tt.input, coinType)
+			testfun, _ := toBytesMap[coinType]
+
+			got, err := testfun(tt.input)
+
 			var goterror string = "(no error)"
 			if err != nil { goterror = err.Error() }
 			if tt.err != nil {
@@ -51,7 +54,10 @@ func RunTestsDecode(t *testing.T, coinType uint32, tests []TestcaseDecode) {
 				t.Errorf("%v %v: Preparation error, input is not valid hex string err %v input %v", coinType, tt.name, err, tt.input)
 				return
 			}
-			got, err := ToString(decoded, coinType)
+			testfun, _ := toStringMap[coinType]
+
+			got, err := testfun(decoded)
+
 			var goterror string = "(no error)"
 			if err != nil { goterror = err.Error() }
 			if tt.err != nil {

--- a/test_runner.go
+++ b/test_runner.go
@@ -1,0 +1,69 @@
+package coincodec
+
+import (
+	"encoding/hex"
+	"reflect"
+	"testing"
+	"strings"
+)
+
+type TestcaseEncode struct {
+	name    string
+	input   string // string
+	output  string // encoded as hex string
+	err     error
+}
+
+type TestcaseDecode struct {
+	name    string
+	input   string // encoded as hex string
+	output  string // string
+	err     error
+}
+
+func RunTestsEncode(t *testing.T, coinType uint32, tests []TestcaseEncode) {
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ToBytes(tt.input, coinType)
+			var goterror string = "(no error)"
+			if err != nil { goterror = err.Error() }
+			if tt.err != nil {
+				if !strings.HasPrefix(goterror, err.Error()) {
+				//if goterror != tt.err.Error() {
+					t.Errorf("%v %v: ToBytes() error = %v, wantErr %v", coinType, tt.name, goterror, tt.err)
+					return
+				}
+			} else {
+				gothex := hex.EncodeToString(got)
+				if !reflect.DeepEqual(gothex, tt.output) {
+					t.Errorf("%v %v: ToBytes() = %v, want %v, err: %v", coinType, tt.name, gothex, tt.output, tt.err)
+				}
+			}
+		})
+	}
+}
+
+func RunTestsDecode(t *testing.T, coinType uint32, tests []TestcaseDecode) {
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			decoded, err := hex.DecodeString(tt.input)
+			if err != nil {
+				t.Errorf("%v %v: Preparation error, input is not valid hex string err %v input %v", coinType, tt.name, err, tt.input)
+				return
+			}
+			got, err := ToString(decoded, coinType)
+			var goterror string = "(no error)"
+			if err != nil { goterror = err.Error() }
+			if tt.err != nil {
+				if goterror != tt.err.Error() {
+					t.Errorf("%v %v: ToString() error = %v, wantErr %v", coinType, tt.name, goterror, tt.err)
+					return
+				}
+			} else {
+				if got != tt.output {
+					t.Errorf("%v %v: ToString() = %v, want %v, err: %v", coinType, tt.name, got, tt.output, goterror)
+				}
+			}
+		})
+	}
+}

--- a/test_runner_test.go
+++ b/test_runner_test.go
@@ -1,0 +1,56 @@
+package coincodec
+
+import (
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/wealdtech/go-slip44"
+)
+
+// Some speical test for driving test_runner in error case without actually failing
+func TestSpecialTests(t *testing.T) {
+	err := RunTestEncode(slip44.BITCOIN, TestcaseEncode {
+		name:   "Positive encode case but expecting excpetion",
+		input:  "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa",
+		err:    errors.New("Error"),
+	})
+	if err == nil {
+		t.Errorf("Expected error error mismatch")
+	}
+	
+	err = RunTestEncode(slip44.BITCOIN, TestcaseEncode {
+		name:  "Negative case but expecting output",
+		input: "bc1vehk7cnpwgz0ta92",
+		output: "0014751e76e8199196d454941c45d1b3a323f1433bd6",
+	})
+	if err == nil {
+		t.Errorf("Expected error error mismatch")
+	}
+
+	err = RunTestDecode(slip44.BITCOIN, TestcaseDecode {
+		name:   "Positive decode case but expecting excpetion",
+		input:  "76a91462e907b15cbf27d5425399ebf6f0fb50ebb88f1888ac",
+		err:    errors.New("Error"),
+	})
+	if err == nil {
+		t.Errorf("Expected error error mismatch")
+	}
+
+	err = RunTestDecode(slip44.BITCOIN, TestcaseDecode {
+		name:  "Negative case but expecting output",
+		input: "00140102",
+		output: "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa",
+	})
+	if err == nil {
+		t.Errorf("Expected error error mismatch")
+	}
+
+	err = RunTestDecode(slip44.BITCOIN, TestcaseDecode {
+		name:  "Not hex",
+		input: "THIS IS NOT A HEX",
+		err:   errors.New("Preparation error"),
+	})
+	if err == nil {
+		t.Errorf("Expected error for not hex")
+	}
+}

--- a/xrp_test.go
+++ b/xrp_test.go
@@ -1,21 +1,14 @@
 package coincodec
 
 import (
-	"encoding/hex"
-	"reflect"
-	"strings"
 	"testing"
 
 	"github.com/pkg/errors"
+	"github.com/wealdtech/go-slip44"
 )
 
-func TestXRPDecodeToBytes(t *testing.T) {
-	tests := []struct {
-		name   string
-		input  string
-		output string
-		err    error
-	}{
+func TestXRPEncodeToBytes(t *testing.T) {
+	tests := []TestcaseEncode {
 		{
 			name:   "Normal",
 			input:  "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
@@ -42,33 +35,15 @@ func TestXRPDecodeToBytes(t *testing.T) {
 			err:   errors.New("base58 decode error: Bad Base58 checksum"),
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := XRPDecodeToBytes(tt.input)
-			if tt.err != nil {
-				if !strings.HasPrefix(err.Error(), tt.err.Error()) {
-					t.Errorf("XRPDecodeToBytes() error = %v, wantErr %v", err, tt.err)
-					return
-				}
-			} else {
-				if !reflect.DeepEqual(hex.EncodeToString(got), tt.output) {
-					t.Errorf("XRPDecodeToBytes() = %v, want %v", hex.EncodeToString(got), tt.output)
-				}
-			}
-		})
-	}
+
+	RunTestsEncode(t, slip44.RIPPLE, tests)
 }
 
-func TestXRPEncodeToString(t *testing.T) {
-	keyhash, _ := hex.DecodeString("004b4e9c06f24296074f7bc48f92a97916c6dc5ea9")
-	keyhash2, _ := hex.DecodeString("05444b4e9c06f24296074f7bc48f92a97916c6dc5ea9000000000000000000")
+func TestXRPDecodeToString(t *testing.T) {
+	keyhash := "004b4e9c06f24296074f7bc48f92a97916c6dc5ea9"
+	keyhash2 := "05444b4e9c06f24296074f7bc48f92a97916c6dc5ea9000000000000000000"
 
-	tests := []struct {
-		name   string
-		input  []byte
-		output string
-		err    error
-	}{
+	tests := []TestcaseDecode {
 		{
 			name:   "Good",
 			input:  keyhash,
@@ -80,19 +55,6 @@ func TestXRPEncodeToString(t *testing.T) {
 			output: "X7qvLs7gSnNoKvZzNWUT2e8st17QPY64PPe7zriLNuJszeg",
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := XRPEncodeToString(tt.input)
-			if tt.err != nil {
-				if err.Error() != tt.err.Error() {
-					t.Errorf("XRPEncodeToString() error = %v, wantErr %v", err, tt.err)
-					return
-				}
-			} else {
-				if got != tt.output {
-					t.Errorf("XRPEncodeToString() = %v, want %v", got, tt.output)
-				}
-			}
-		})
-	}
+
+	RunTestsDecode(t, slip44.RIPPLE, tests)
 }

--- a/zilliqa_test.go
+++ b/zilliqa_test.go
@@ -1,69 +1,33 @@
 package coincodec
 
 import (
-	"encoding/hex"
-	"reflect"
 	"testing"
+
+	"github.com/wealdtech/go-slip44"
 )
 
-func TestZilliqaDecodeToBytes(t *testing.T) {
-	tests := []struct {
-		name   string
-		input  string
-		output string
-		err    error
-	}{
+func TestZilliqaEncodeToBytes(t *testing.T) {
+	tests := []TestcaseEncode {
 		{
 			name:   "Normal",
 			input:  "zil10lx2eurx5hexaca0lshdr75czr025cevqu83uz",
 			output: "7fccacf066a5f26ee3affc2ed1fa9810deaa632c",
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := ZilliqaDecodeToBytes(tt.input)
-			if tt.err != nil {
-				if err.Error() != tt.err.Error() {
-					t.Errorf("ZilliqaDecodeToBytes() error = %v, wantErr %v", err, tt.err)
-					return
-				}
-			} else {
-				if !reflect.DeepEqual(hex.EncodeToString(got), tt.output) {
-					t.Errorf("ZilliqaDecodeToBytes() = %v, want %v", hex.EncodeToString(got), tt.output)
-				}
-			}
-		})
-	}
+
+	RunTestsEncode(t, slip44.ZILLIQA, tests)
 }
 
-func TestZilliqaEncodeToString(t *testing.T) {
-	keyhash, _ := hex.DecodeString("7fccacf066a5f26ee3affc2ed1fa9810deaa632c")
+func TestZilliqaDecodeToString(t *testing.T) {
+	keyhash := "7fccacf066a5f26ee3affc2ed1fa9810deaa632c"
 
-	tests := []struct {
-		name   string
-		input  []byte
-		output string
-		err    error
-	}{
+	tests := []TestcaseDecode {
 		{
 			name:   "Good",
 			input:  keyhash,
 			output: "zil10lx2eurx5hexaca0lshdr75czr025cevqu83uz",
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := ZilliqaEncodeToString(tt.input)
-			if tt.err != nil {
-				if err.Error() != tt.err.Error() {
-					t.Errorf("ZilliqaEncodeToString() error = %v, wantErr %v", err, tt.err)
-					return
-				}
-			} else {
-				if got != tt.output {
-					t.Errorf("ZilliqaEncodeToString() = %v, want %v", got, tt.output)
-				}
-			}
-		})
-	}
+
+	RunTestsDecode(t, slip44.ZILLIQA, tests)
 }


### PR DESCRIPTION
Each coin type had some lengthy code for running test cases, some slightly different, some with bugs.  E.g. it did not handle well the cases when there was no error expected but there was error, or when there was error expected but there was no error (in this case it used the nil err value!).
Test usage is unified now.
Drawback: each unit test call goes to the common codec dispatcher code, not directly to the coin-specific handler method.

Further improvement:  extract all test calls into a large data-only json file.  Could be even factored out into an own, language-independent repo.